### PR TITLE
Add cross-chain HOPR token balance

### DIFF
--- a/src/strategies/hopr-uni-lp-farm/examples.json
+++ b/src/strategies/hopr-uni-lp-farm/examples.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Get nominal HOPR tokens from HOPR LP token, incl. those staked in the HoprFarm",
+    "strategy": {
+      "name": "hopr-uni-lp-farm",
+      "params": {
+        "farmAddress": "0x2fc0e2cfe5d6ea300d555e5907319a5f7e09884f",
+        "uniPoolAddress": "0x92c2fc5f306405eab0ff0958f6d85d7f8892cf4d",
+        "hoprAddress": "0xf5581dfefd8fb0e4aec526be659cfab1f8c781da",
+        "daiAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "farmDeployBlock": 12094980,
+        "start": 11945961,
+        "xHoprAddress": "0xd057604a14982fe8d88c5fc25aac3267ea142a08",
+        "wxHoprAddress": "0xd4fdec44db9d44b8f2b6d529620f9c0c7066a2c1"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x2d8e358487feda42629274ce041f98629bf65cf3",
+      "0x52def6c112bffc66fc8c8258539d4d8c30c5000c"
+    ],
+    "snapshot": "latest"
+  }
+]

--- a/src/strategies/hopr-uni-lp-farm/examples.json
+++ b/src/strategies/hopr-uni-lp-farm/examples.json
@@ -17,7 +17,9 @@
     "network": "1",
     "addresses": [
       "0x2d8e358487feda42629274ce041f98629bf65cf3",
-      "0x52def6c112bffc66fc8c8258539d4d8c30c5000c"
+      "0x52def6c112bffc66fc8c8258539d4d8c30c5000c",
+      "0x000000359d837dbc86ffcb8be6057062bf1fc1ff",
+      "0x0000000000000000000000000000000000000000"
     ],
     "snapshot": "latest"
   }

--- a/src/strategies/hopr-uni-lp-farm/index.ts
+++ b/src/strategies/hopr-uni-lp-farm/index.ts
@@ -1,6 +1,7 @@
 import { formatUnits } from '@ethersproject/units';
 import { BigNumber } from '@ethersproject/bignumber';
-import { getScores, multicall } from '../../utils';
+import { getScores, multicall, subgraphRequest } from '../../utils';
+import { getBlockNumber } from '../../utils/web3';
 
 export const author = 'hoprnet';
 export const version = '0.1.0';
@@ -68,7 +69,50 @@ const tokenAndPoolAbi = [
     stateMutability:"view",
     type:"function"
  }
-]
+];
+
+const XDAI_BLOCK_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/1hive/xdai-blocks';
+const HOPR_XDAI_SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/hoprnet/hopr-on-xdai';
+
+async function getXdaiBlockNumber (timestamp: number): Promise<number> {
+  const query = {
+    blocks: {
+      __args: {
+        first: 1,
+        orderBy: 'number',
+        orderDirection: 'desc',
+        where: {
+          timestamp_lte: timestamp
+        }
+      },
+      number: true,
+      timestamp: true
+    }
+  };
+  const data = await subgraphRequest(XDAI_BLOCK_SUBGRAPH_URL, query);
+  return Number(data.blocks[0].number);
+}
+
+async function xHoprSubgraphQuery (addresses: string[], blockNumber: number): Promise<{[propName: string]:number}> {
+  const query = {
+    accounts: {
+      __args: {
+        block: {
+          number: blockNumber
+        },
+        where: {
+          id_in: addresses.map(adr => adr.toLowerCase())
+        }
+      },
+      id: true,
+      totalBalance: true
+    }
+  }
+  const data = await subgraphRequest(HOPR_XDAI_SUBGRAPH_URL, query);
+  // map result (data.accounts) to addresses
+  const entries = data.accounts.map(d => [d.id, Number(d.totalBalance)])
+  return Object.fromEntries(entries);
+}
 
 export async function strategy(
   space,
@@ -104,6 +148,14 @@ export async function strategy(
     ? res.slice(2, 2 + addresses.length).map((r, i) => (r[0] as BigNumber).add(res[2 + i + addresses.length][1] as BigNumber))
     : res.slice(2).map(r => r[0] as BigNumber);
 
+  // get block timestamp to search on xDai subgraph
+  const snapshotTimestamp = (await provider.getBlock(blockTag)).timestamp;
+  const snapshotXdaiBlock = await getXdaiBlockNumber(snapshotTimestamp);
+  // get and parse xHOPR and wxHOPR balance
+  const hoprOnXdaiBalance = await xHoprSubgraphQuery(addresses, snapshotXdaiBlock);
+  const hoprOnXdaiScore = addresses.map(address => hoprOnXdaiBalance[address] ?? 0)
+
+  // get HOPR token balance
   const hoprScore = await getScores(space, [{
       name: "erc20-balance-of",
       params: {
@@ -120,6 +172,7 @@ export async function strategy(
         value.mul(hoprBalanceOfPool[0]).div(poolTotalSupply[0]
       ), 18))
       + hoprScore[0][addresses[i]] // HOPR token balance
+      + hoprOnXdaiScore[i] // xHOPR + wxHOPR balance
     ])
   );
 }

--- a/src/strategies/hopr-uni-lp-farm/index.ts
+++ b/src/strategies/hopr-uni-lp-farm/index.ts
@@ -1,0 +1,125 @@
+import { formatUnits } from '@ethersproject/units';
+import { BigNumber } from '@ethersproject/bignumber';
+import { getScores, multicall } from '../../utils';
+
+export const author = 'hoprnet';
+export const version = '0.1.0';
+
+const tokenAndPoolAbi = [
+  {
+    constant:true,
+    inputs:[
+       {
+          internalType:"address",
+          name:"",
+          type:"address"
+       }
+    ],
+    name:"balanceOf",
+    outputs:[
+       {
+          internalType:"uint256",
+          name:"",
+          type:"uint256"
+       }
+    ],
+    payable:false,
+    stateMutability:"view",
+    type:"function"
+  },
+  {
+    constant:true,
+    inputs:[
+
+    ],
+    name:"totalSupply",
+    outputs:[
+      {
+          internalType:"uint256",
+          name:"",
+          type:"uint256"
+      }
+    ],
+    payable:false,
+    stateMutability:"view",
+    type:"function"
+  },
+  {
+    inputs:[
+       {
+          internalType:"address",
+          name:"",
+          type:"address"
+       }
+    ],
+    name:"liquidityProviders",
+    outputs:[
+       {
+          internalType:"uint256",
+          name:"claimedUntil",
+          type:"uint256"
+       },
+       {
+          internalType:"uint256",
+          name:"currentBalance",
+          type:"uint256"
+       }
+    ],
+    stateMutability:"view",
+    type:"function"
+ }
+]
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const res = await multicall(
+    network,
+    provider,
+    tokenAndPoolAbi,
+    [
+      [options.hoprAddress, 'balanceOf', [options.uniPoolAddress]],
+      [options.uniPoolAddress, 'totalSupply', []],
+    ].concat(
+      addresses.map(
+        (address: any) => [options.uniPoolAddress, 'balanceOf', [address]]
+      )
+    ).concat(
+      blockTag >= options.farmDeployBlock || blockTag === 'latest' ? addresses.map(
+        (address: any) => [options.farmAddress, 'liquidityProviders', [address]]
+      ) : []
+    ),
+    { blockTag }
+  );
+
+  const hoprBalanceOfPool = res[0];
+  const poolTotalSupply = res[1];
+  const response: BigNumber[] = blockTag >= options.farmDeployBlock || blockTag === 'latest'
+    ? res.slice(2, 2 + addresses.length).map((r, i) => (r[0] as BigNumber).add(res[2 + i + addresses.length][1] as BigNumber))
+    : res.slice(2).map(r => r[0] as BigNumber);
+
+  const hoprScore = await getScores(space, [{
+      name: "erc20-balance-of",
+      params: {
+        address: options.hoprAddress,
+        symbol: "HOPR",
+        decimals: 18
+      }
+    }], "1", provider, addresses, snapshot);
+
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i], // LP token amount * pool's HOPR token balnce / total pool supply
+      parseFloat(formatUnits(
+        value.mul(hoprBalanceOfPool[0]).div(poolTotalSupply[0]
+      ), 18))
+      + hoprScore[0][addresses[i]] // HOPR token balance
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -80,6 +80,7 @@ import { strategy as xseen } from './xseen';
 import { strategy as molochAll } from './moloch-all';
 import { strategy as molochLoot } from './moloch-loot';
 import { strategy as erc721Enumerable } from './erc721-enumerable';
+import { strategy as hoprUniLpFarm } from './hopr-uni-lp-farm';
 
 export default {
   balancer,
@@ -163,5 +164,6 @@ export default {
   api,
   xseen,
   'moloch-all': molochAll,
-  'moloch-loot': molochLoot
+  'moloch-loot': molochLoot,
+  'hopr-uni-lp-farm': hoprUniLpFarm
 };


### PR DESCRIPTION
Changes proposed in this pull request:
- Calculate staked HOPR-DAI UNI-V2 token for farmers of HOPR liquidity mining program.
- Calculate nominal HOPR token balance for HOPR-DAI UNI-V2 token (held + staked) for liquidity providers.
- Include `erc20-balance-of`mainnet HOPR token
- Take all the balances above into consideration and effectively calculate the nominal HOPR token balance 
